### PR TITLE
feat: switch to OpenAI API

### DIFF
--- a/src/app/api/recipes/route.js
+++ b/src/app/api/recipes/route.js
@@ -2,8 +2,7 @@ import { NextResponse } from "next/server";
 import OpenAI from "openai";
 
 const openai = new OpenAI({
-  apiKey: process.env.DEEPSEEK_API_KEY || "", // ← ahora usa DEEPSEEK_API_KEY
-  baseURL: "https://api.deepseek.com", // ← apunta a DeepSeek
+  apiKey: process.env.OPENAI_API_KEY || "", // Usa OPENAI_API_KEY
 });
 
 // Función para limpiar el JSON
@@ -105,10 +104,10 @@ export async function POST(request) {
       { role: "user", content: userPrompt },
     ];
 
-    console.log("📌 Enviando prompt a DeepSeek...");
+    console.log("📌 Enviando prompt a OpenAI...");
 
     const response = await openai.chat.completions.create({
-      model: "deepseek-chat", // ← modelo DeepSeek
+      model: "gpt-4o-mini",
       messages,
       temperature: 1.2,
       max_tokens: 800,
@@ -119,9 +118,9 @@ export async function POST(request) {
       response.choices.length === 0 ||
       !response.choices[0].message?.content
     ) {
-      console.error("❌ Respuesta inesperada de DeepSeek:", response);
+      console.error("❌ Respuesta inesperada de OpenAI:", response);
       return NextResponse.json(
-        { error: "Respuesta inválida de DeepSeek." },
+        { error: "Respuesta inválida de OpenAI." },
         { status: 500 }
       );
     }
@@ -153,12 +152,12 @@ export async function POST(request) {
       recipe = JSON.parse(cleanedJsonContent);
     } catch (error) {
       console.error(
-        "❌ Error al analizar JSON de DeepSeek:",
+        "❌ Error al analizar JSON de OpenAI:",
         error,
         cleanedJsonContent
       );
       return NextResponse.json(
-        { error: "Error al procesar la respuesta de DeepSeek." },
+        { error: "Error al procesar la respuesta de OpenAI." },
         { status: 500 }
       );
     }

--- a/src/app/api/remedies/route.js
+++ b/src/app/api/remedies/route.js
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
 
-// Cliente DeepSeek configurado
+// Cliente OpenAI configurado
 const openai = new OpenAI({
-  apiKey: process.env.DEEPSEEK_API_KEY,
-  baseURL: "https://api.deepseek.com",
+  apiKey: process.env.OPENAI_API_KEY,
 });
 
-// Contexto del sistema para DeepSeek
+// Contexto del sistema para OpenAI
 const systemPrompt = `
 [ESPAÑOL] Eres un experto en medicina tradicional y remedios naturales con 30 años de experiencia. Tu tarea es generar remedios caseros seguros **en formato JSON** basados en los parámetros que te proporcionaré.
 
@@ -82,16 +81,16 @@ export async function POST(request) {
       Respuesta EXCLUSIVAMENTE en el formato JSON especificado, sin texto adicional.
     `.trim();
 
-    console.log("📤 Enviando a DeepSeek:", {
+    console.log("📤 Enviando a OpenAI:", {
       symptoms,
       remedyType,
       duration,
       restrictions,
     });
 
-    // Llamada a DeepSeek
+    // Llamada a OpenAI
     const response = await openai.chat.completions.create({
-      model: "deepseek-chat",
+      model: "gpt-4o-mini",
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },


### PR DESCRIPTION
## Summary
- use `OPENAI_API_KEY` and OpenAI default endpoint
- generate recipes and remedies with `gpt-4o-mini`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ff0b822c08323b33ba78bb737fa1e